### PR TITLE
Rename `quicksilver-module` to `quicksilver-script`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,21 @@
 # Quicksilver Composer Installer #
 
-Creates a new "type" in Composer for `quicksilver-modules` so you can treat them separately in Composer installations.  This allows you to include Quicksilver scripts as part of a composer based project on Pantheon[https://pantheon.io].
+Creates a new "type" in Composer for `quicksilver-script`s so you can treat them separately in Composer installations.  This allows you to include Quicksilver scripts as part of a composer based project on Pantheon[https://pantheon.io].
+
+To use this custom installer, require it in your project (root-level) composer.json file. Then, any Composer project of type `quicksiver-script` will be placed in the directory `web/private/scripts/quicksilver`. This path may be customized in the `installer-paths` item in `extras`.
+
+The `web/private/scripts/quicksilver` path (or your customized path) should be added to your project's .gitignore.
 
 ## Example composer.json file ##
 
 ```
 {
   "require": {
-    "rvtraveller/qs-revert-all-features-d7": "1.0"
+    "rvtraveller/qs-composer-installer": "1.0"
   },
   "extra": {
     "installer-paths": {
-      "web/private/scripts/quicksilver/{$name}": ["type:quicksilver-module"]
+      "web/private/scripts/quicksilver/{$name}": ["type:quicksilver-script"]
     }
   }
 }

--- a/src/QuicksilverComposerInstaller.php
+++ b/src/QuicksilverComposerInstaller.php
@@ -8,7 +8,7 @@ use Composer\Installer\LibraryInstaller;
 class QuicksilverComposerInstaller extends LibraryInstaller
 {
 
-  
+
   /**
    * Replace vars in a path
    *
@@ -60,7 +60,7 @@ class QuicksilverComposerInstaller extends LibraryInstaller
    */
   public function getInstallPath(PackageInterface $package, $frameworkType = '')
   {
-    $type = $package->getType();
+    $packageType = $package->getType();
 
     $prettyName = $package->getPrettyName();
     if (strpos($prettyName, '/') !== false) {
@@ -70,7 +70,11 @@ class QuicksilverComposerInstaller extends LibraryInstaller
       $name = $prettyName;
     }
 
-    $availableVars = compact('name', 'vendor', 'type');
+    $availableVars = [
+      'name' => $name,
+      'vendor' => $vendor,
+      'type' => $packageType
+    ];
 
     $extra = $package->getExtra();
     if (!empty($extra['installer-name'])) {
@@ -80,12 +84,17 @@ class QuicksilverComposerInstaller extends LibraryInstaller
     if ($this->composer->getPackage()) {
       $extra = $this->composer->getPackage()->getExtra();
       if (!empty($extra['installer-paths'])) {
-        $customPath = $this->mapCustomInstallPaths($extra['installer-paths'], $prettyName, $type, $vendor);
+        $customPath = $this->mapCustomInstallPaths($extra['installer-paths'], $prettyName, $packageType, $vendor);
         if ($customPath !== false) {
           return $this->templatePath($customPath, $availableVars);
         }
       }
     }
+
+    $locations = [
+      'quicksilver-script' => 'web/private/scripts/quicksilver/{$name}/',
+      'quicksilver-module' => 'web/private/scripts/quicksilver/{$name}/',
+    ];
 
     return $this->templatePath($locations[$packageType], $availableVars);
   }
@@ -96,7 +105,7 @@ class QuicksilverComposerInstaller extends LibraryInstaller
    */
   public function supports($packageType)
   {
-    return 'quicksilver-module' === $packageType;
+    return in_array($packageType, ['quicksilver-script', 'quicksilver-module']);
   }
 
 }

--- a/src/QuicksilverComposerInstallerPlugin.php
+++ b/src/QuicksilverComposerInstallerPlugin.php
@@ -10,6 +10,10 @@ class QuicksilverComposerInstallerPlugin implements PluginInterface
 {
   public function activate(Composer $composer, IOInterface $io)
   {
+    // Strange autoloading problem on CircleCI
+    if (!class_exists(QuickSilverComposerInstaller::class)) {
+      include_once __DIR__ . '/QuicksilverComposerInstaller.php';
+    }
     $installer = new QuickSilverComposerInstaller($io, $composer);
     $composer->getInstallationManager()->addInstaller($installer);
   }


### PR DESCRIPTION
A few other fixes included as well, including a reasonable default path for Quicksilver scripts.

Note that I needed to add the include_once of `QuicksilverComposerInstaller.php` in order to get this installer to work on CircleCI. This is odd, because everything worked fine locally without this workaround.

I also submitted https://github.com/composer/installers/pull/340 to add this type to composer/installers.